### PR TITLE
Implement RefineNet

### DIFF
--- a/refinenet/README.md
+++ b/refinenet/README.md
@@ -1,0 +1,22 @@
+# RefineNet
+
+
+* RefineNet was originally proposed in:
+[1] Guosheng Lin, Anton Milan, Chunhua Shen, Ian Reid
+    RefineNet: Multi-Path Refinement Networks for High-Resolution Semantic Segmentatiion. arXiv:1611.06612
+
+* The RefineNet implemented in this module is based on [1]
+
+* Since RefineNet relies on ResNet, we use ResNet-50 for this implementation
+    * `resnet_v2.py` and `resnet_utils.py` are copied from github repo `tensorflow/models/research/slim/nets`
+    * resnet_v2_50 in `resnet_v2.py` is used to create the 50-layer ResNet
+
+* The key differences between this implementation and the one proposed in [1]:
+    * [1] uses ResNet pretrained on ImageNet recognition tasks, while this implementaton is trained end-to-end
+    * [1] uses 512 filters for each conv layer of RefineNet-4 block, while this implementation uses 256 instead, to keep it consistent with the remaining RefineNet blocks
+
+* This implementation only supports input images that are 512x512x3. Other sizes might not work.
+
+* tensorflow 1.5.0 or above is required. Using lower versions of tensorflow may generate "incompatible dimension" errors.
+
+* `pretrain_resnet.py` can be used to pretrain ResNet50 defined by slim's resnet_v2_50 in `resnet_v2.py`. `wrangle_tiny_imagenet.py` is used to prepare the raw Tiny ImageNet dataset to the file structure that Keras image generator supports.

--- a/refinenet/pretrain_resnet.py
+++ b/refinenet/pretrain_resnet.py
@@ -1,0 +1,157 @@
+"""
+This script trains ResNet-50 on a classification task, Tiny ImageNet dataset (200 classes)
+Use wrangle_tiny_imagenet.py to prepare the raw Tiny ImageNet dataset for this script
+"""
+import os
+import datetime
+import argparse
+
+import numpy as np
+import tensorflow as tf
+from keras.preprocessing.image import ImageDataGenerator
+
+from resnet.resnet_v2 import resnet_v2_50 as resnet_50
+
+def pretrain_resnet(logdir,
+                    path_to_imagenet_data,
+                    num_classes=200,
+                    input_shape=(256, 256),
+                    learning_rate=1e-4,
+                    batch_size=32,
+                    max_itrs=1e5,
+                    print_train_every_itrs=20,
+                    validation_every_itrs=200):
+    """Pre-train the resnet componenet of RefineNet-ResNet on ImageNet dat
+    """
+    # create logdir if its not there
+    if not os.path.isdir(logdir):
+        os.mkdir(logdir)
+
+    tf.reset_default_graph()
+
+    # placeholders for images and their labels
+    input_images = tf.placeholder(tf.float32, shape=[None, input_shape[0], input_shape[1], 3], name="resnet_input_images")
+    labels = tf.placeholder(tf.int32, shape=[None], name="resnet_labels")
+
+    # build ResNet
+    resnet_logits, end_points = resnet_50(inputs=input_images,
+                                          num_classes=num_classes,
+                                          is_training=True,
+                                          scope="resnet_v2")
+
+    # top-1 error
+    t1_err = 1 - tf.reduce_mean(tf.cast(tf.nn.in_top_k(predictions=resnet_logits, targets=labels, k=1), tf.float32))
+
+    # top-5 error
+    t5_err = 1 - tf.reduce_mean(tf.cast(tf.nn.in_top_k(predictions=resnet_logits, targets=labels, k=5), tf.float32))
+
+    # compute loss for classification task
+    loss = tf.reduce_mean((tf.nn.sparse_softmax_cross_entropy_with_logits(
+                           logits=resnet_logits, labels=labels, name="resnet_entropy")))
+
+    # global step for training
+    global_step = tf.get_variable("resnet_global_step", dtype=tf.int32, initializer=0)
+
+    sess = tf.Session()
+
+    # get train step
+    train_op = tf.train.AdamOptimizer(learning_rate, name='resnet_Adam').minimize(loss, global_step=global_step)
+
+    # initialize all variables
+    sess.run(tf.global_variables_initializer())
+
+    # restore weights if logdir has any checkpoints
+    saver = tf.train.Saver()
+    ckpt = tf.train.get_checkpoint_state(logdir)
+    if ckpt and ckpt.model_checkpoint_path:
+        saver.restore(sess, ckpt.model_checkpoint_path)
+
+    # tensorboard related
+    tf.summary.scalar('loss', loss)
+    tf.summary.scalar('top1 error', t1_err)
+    tf.summary.scalar('top5 error', t5_err)
+    merged = tf.summary.merge_all()
+    train_writer = tf.summary.FileWriter(logdir+'/train', sess.graph)
+    val_writer = tf.summary.FileWriter(logdir+'/val', sess.graph)
+
+    # prepare data
+    tiny_imagenet_classes = []
+    with open(os.path.join(path_to_imagenet_data, 'wnids.txt'), 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            wnid = line.strip()
+            tiny_imagenet_classes.append(wnid)
+
+    train_datagen = ImageDataGenerator(samplewise_center=True)
+    train_datagen = train_datagen.flow_from_directory(os.path.join(path_to_imagenet_data, 'train_keras'),
+                                                      classes=tiny_imagenet_classes,
+                                                      class_mode='sparse',
+                                                      target_size=input_shape,
+                                                      batch_size=batch_size)
+
+    val_datagen = ImageDataGenerator(samplewise_center=True)
+    val_datagen = val_datagen.flow_from_directory(os.path.join(path_to_imagenet_data, 'val_keras'),
+                                                  classes=tiny_imagenet_classes,
+                                                  class_mode='sparse',
+                                                  target_size=input_shape,
+                                                  batch_size=batch_size)
+
+    # training loop
+    best_val_error = float('inf')
+    total_t1_err_val, total_t5_err_val = 0, 0
+    for itr, batch_data in enumerate(train_datagen):
+        if itr >= max_itrs:
+            break
+        
+        # train step
+        X_train_batch, y_train_batch = batch_data
+        summary, loss_val, t1_err_val, t5_err_val, _ = sess.run([merged, loss, t1_err, t5_err, train_op],
+                                                       feed_dict={input_images: X_train_batch, labels: y_train_batch})
+        g_val = sess.run(global_step) - 1
+        train_writer.add_summary(summary, g_val)
+
+        if itr % print_train_every_itrs == 0:
+            print("Itr {}: training loss {}, top-1 error {}, top-5 error {}".format(itr, loss_val, t1_err_val, t5_err_val))
+        
+        # validation
+        X_val_batch, y_val_batch = next(val_datagen)
+        summary, t1_err_val, t5_err_val = sess.run([merged, t1_err, t5_err], feed_dict={input_images: X_val_batch, labels: y_val_batch})
+        val_writer.add_summary(summary, g_val)
+        total_t1_err_val += t1_err_val
+        total_t5_err_val += t5_err_val
+        
+        if itr % validation_every_itrs == 0:
+            # aggregate validation stats
+            total_t1_err_val /= min(itr+1, validation_every_itrs)
+            total_t5_err_val /= min(itr+1, validation_every_itrs)
+            print("[{}] VALIDATION: top-1 error {}, top-5 error {}".format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"),
+                                                                           total_t1_err_val,
+                                                                           total_t5_err_val))
+            # compare results
+            val_error = total_t5_err_val
+            total_t1_err_val, total_t5_err_val = 0, 0
+            if val_error < best_val_error:
+                best_val_error = val_error
+                # save model
+                saver.save(sess, os.path.join(logdir, "resnet50.ckpt"), g_val)
+                print("[{}] Model saved to {}".format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"),
+                                                      os.path.join(logdir, "resnet50.ckpt-"+str(g_val))))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--logdir", default="resnet50", help="Which directory the model will be saved to or loaded from")
+    parser.add_argument("--path_to_data", default=None, help="Specify the path to imagenet data")
+    parser.add_argument("--batch_size", type=int, default=32, help="Number of training/validation examples for each batch")
+    parser.add_argument("--learning_rate", type=float, default=1e-4, help="Learning rate to use")
+    parser.add_argument("--max_itrs", type=int, default=1e5, help="Set maximum number of training iterations")
+    parser.add_argument("--print_train_every_itrs", type=int, default=20, help="How often to print out training stats")
+    parser.add_argument("--validation_every_itrs", type=int, default=200, help="How often to print out validation stats")
+    args = parser.parse_args()
+
+    pretrain_resnet(args.logdir,
+                    args.path_to_data,
+                    batch_size=args.batch_size,
+                    learning_rate=args.learning_rate,
+                    max_itrs=args.max_itrs,
+                    print_train_every_itrs=args.print_train_every_itrs,
+                    validation_every_itrs=args.validation_every_itrs)

--- a/refinenet/refinenet.py
+++ b/refinenet/refinenet.py
@@ -1,0 +1,263 @@
+"""Contains implementation of RefineNet on ResNet-50
+"""
+
+import numpy as np
+import tensorflow as tf
+
+from resnet.resnet_v2 import resnet_v2_50 as resnet_50
+
+NUM_REFINE_FILTERS = 256
+INPUT_IMAGE_SHAPE = (512, 512)
+
+class RefineNet(object):
+    def __init__(self,
+                 input_shape,
+                 is_training,
+                 num_classes,
+                 learning_rate=1e-4,
+                 network_storage_dir=None):
+        """Construct the RefineNet object."""
+        self.input_shape = input_shape
+        self.is_training = is_training
+        self.network_weights_loc = network_storage_dir
+        self.num_classes = num_classes
+        self.learning_rate = learning_rate
+        self.data_format = "channels_last"
+
+        tf.reset_default_graph()
+
+        # Set up the placeholder tensors to use as input/output to network
+        image = tf.placeholder(
+            tf.float32, shape=[None, input_shape[0], input_shape[1], 3],
+            name="input_image")
+        annotation = tf.placeholder(
+            tf.int32, shape=[None, input_shape[0], input_shape[1], 1],
+            name="annotation")
+
+        self.placeholders = {"image": image,
+                             "annotation": annotation}
+
+        # Build the computational graph
+        self.predict_with_network, self.logits = self.build_computational_graph()
+
+        self.loss = tf.reduce_mean(
+                       (tf.nn.sparse_softmax_cross_entropy_with_logits(
+                        logits=self.logits, labels=tf.squeeze(annotation, squeeze_dims=[3]), name="xentropy")))
+
+        # get train op
+        trainable_var = tf.trainable_variables()
+        self.train_op = self.train(self.loss, trainable_var)
+
+        self.num_params = self.compute_total_num_params()
+
+        self.sess = tf.Session()
+
+        self.saver = tf.train.Saver()
+
+        # Initialize the graph, then load the network into memory.
+        self.sess.run(tf.global_variables_initializer())
+        if network_storage_dir:
+            self.load_network_weights(self.network_weights_loc)
+
+    def load_network_weights(self, path_to_network):
+        """Load the network weights contained in `path_to_network` into memory."""
+        ckpt = tf.train.get_checkpoint_state(path_to_network)
+        if ckpt and ckpt.model_checkpoint_path:
+            self.saver.restore(self.sess, ckpt.model_checkpoint_path)
+            self.weights_loaded = True
+        else:
+            self.weights_loaded = False
+
+    def compute_total_num_params(self):
+        """Compute the number of parameters of this model"""
+        total_parameters = 0
+        for variable in tf.trainable_variables():
+            shape = variable.get_shape()
+            variable_parameters = 1
+            for dim in shape:
+                variable_parameters *= dim.value
+            total_parameters += variable_parameters
+        return total_parameters
+
+    def build_computational_graph(self):
+        """Build the semantic segmentation network's computational graph."""
+
+        processed_image = self.placeholders["image"]
+
+        if self.data_format == "channels_first":
+            processed_image = tf.transpose(processed_image, [0, 3, 1, 2])
+
+        num_filters = NUM_REFINE_FILTERS
+
+        def residual_conv_unit(x):
+            """Residual Convolutional Unit"""
+            # ReLU -> 3x3 Conv -> ReLU -> 3x3 Conv
+            relu = tf.nn.relu(x)
+            conv = tf.layers.conv2d(relu, filters=num_filters,
+                                    kernel_size=3, strides=1, padding="same",
+                                    data_format=self.data_format)
+            relu = tf.nn.relu(conv)
+            conv = tf.layers.conv2d(relu, filters=num_filters,
+                                    kernel_size=3, strides=1, padding="same",
+                                    data_format=self.data_format)
+
+            # residual connection
+            compare_dimension = 1 if self.data_format == "channels_first" else 3
+            if x.get_shape()[compare_dimension] == conv.get_shape()[compare_dimension]:
+                # if same dimension, then add them up
+                out = tf.add(x, conv)
+            else:
+                # if different dimension, then project shortcut x to have the same dimension with conv
+                # because the number of channels can be different for x and conv
+                x_conv = tf.layers.conv2d(x, filters=num_filters,
+                                          kernel_size=1, strides=1, padding="same",
+                                          data_format=self.data_format)
+                out = tf.add(x_conv, conv)
+            return out
+
+        def multi_resolution_fusion(low_res_input, high_res_input):
+            """Multi-Resolution Fusion
+               we assume both the width and height of low_res_out are half of high_res_out
+            """
+            def conv_and_upsample(x, stride):
+                """Helper function to create (Conv->Deconv)"""
+                conv = tf.layers.conv2d(x, filters=num_filters, kernel_size=3,
+                                        strides=stride, padding="same",
+                                        data_format=self.data_format)
+                # transposed convolutional layer to upsample the feature map
+                upsample = tf.layers.conv2d_transpose(conv, filters=num_filters, kernel_size=3,
+                                                      strides=2, padding="same",
+                                                      data_format=self.data_format)
+                return upsample
+            if low_res_input is not None:
+                # we upsample the low resolution input to have the same dimension of high resolution input
+                low_res_out = conv_and_upsample(low_res_input, stride=1)
+            high_res_out = conv_and_upsample(high_res_input, stride=2)
+            if low_res_input is not None:
+                return tf.add(low_res_out, high_res_out)
+            else:
+                return high_res_out
+
+        def chained_residual_pooling(x):
+            """Chained_Residual_Pooling"""
+            def pool_and_conv(x):
+                """Help function to create (Max_pool->Conv)"""
+                ksize = [1, 1, 5, 5] if self.data_format == "channels_first" else [1, 5, 5, 1]
+                data_format = "NCHW" if self.data_format == "channels_first" else "NHWC"
+                max_pool = tf.nn.max_pool(x, ksize=ksize, strides=[1, 1, 1, 1], padding="SAME", data_format=data_format)
+                conv = tf.layers.conv2d(max_pool, filters=num_filters,
+                                        kernel_size=3, strides=1, padding="same",
+                                        data_format=self.data_format)
+                return conv
+
+            relu = tf.nn.relu(x)
+            pool_conv_out = relu
+            sum_out = relu
+            # the number of (max_pool->conv) is a design choice
+            # change num_pool_conv_units to suit your own model
+            num_pool_conv_units = 2
+            for i in range(num_pool_conv_units):
+                pool_conv_out = pool_and_conv(pool_conv_out)
+                sum_out = tf.add(sum_out, pool_conv_out)
+            return sum_out
+
+        def refine_block(low_res_input, high_res_input):
+            """ RefineNet Block """
+            # Adaptive Conv
+            low_res_adap_conv_out = None
+            if low_res_input is not None:
+                low_res_adap_conv_out = residual_conv_unit(low_res_input)
+                low_res_adap_conv_out = residual_conv_unit(low_res_adap_conv_out)
+            high_res_adap_conv_out = residual_conv_unit(high_res_input)
+            high_res_adap_conv_out = residual_conv_unit(high_res_adap_conv_out)
+
+            # Multi-resolution Fusion
+            mrf_out = multi_resolution_fusion(low_res_adap_conv_out, high_res_adap_conv_out)
+
+            # Chained Residual Pooling
+            crp_out = chained_residual_pooling(mrf_out)
+
+            out_conv = residual_conv_unit(crp_out)
+
+            return out_conv
+
+
+        # build ResNet
+        nets, end_points = resnet_50(inputs=processed_image,
+                                     num_classes=self.num_classes,
+                                     is_training=self.is_training,
+                                     scope="resnet_v2")
+
+        # get outputs from ResNet that we want to refine on
+        multi_res_outs = [end_points['resnet_v2/block1/unit_2/bottleneck_v2'],
+                          end_points['resnet_v2/block2/unit_3/bottleneck_v2'],
+                          end_points['resnet_v2/block3/unit_5/bottleneck_v2'],
+                          end_points['resnet_v2/block4']]
+
+        # refine outputs recursively
+        refine_out = None
+        
+        # refine feature maps recursively
+        # start from the highest-level feature maps
+        # we need to refine 4 feature maps in total
+        for i in [3, 2, 1, 0]:
+            refine_out = refine_block(refine_out, multi_res_outs[i])
+
+
+        # two more rcus right before the final scoring layer
+        for i in range(2):        
+            refine_out = residual_conv_unit(refine_out)
+        
+        # scoring layer
+        logits = tf.layers.conv2d(refine_out, filters=self.num_classes,
+                                      kernel_size=3, strides=1, padding="same",
+                                      data_format=self.data_format)
+
+        if self.data_format == "channels_first":
+            logits = tf.transpose(logits, [0, 2, 3, 1])
+
+        # bilinearly up-sample to match the dimension of the input image
+        logits = tf.image.resize_images(logits, self.input_shape)
+
+        annotation_pred = tf.argmax(logits, axis=3, name="prediction", output_type=tf.int32)
+
+        return tf.expand_dims(annotation_pred, dim=3), logits
+
+    def train(self, loss_val, var_list):
+        """Add training operations to computational graph."""
+        self.global_step = tf.get_variable(name="global_step", dtype=tf.int32, initializer=0)
+        update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+        with tf.control_dependencies(update_ops):
+            optimizer = tf.train.AdamOptimizer(self.learning_rate)
+            grads = optimizer.compute_gradients(loss_val, var_list=var_list)
+            return optimizer.apply_gradients(grads, self.global_step)
+
+if __name__ == "__main__":
+    """ run this main function to test the model """
+
+    # build RefineNet
+    model = RefineNet(input_shape=INPUT_IMAGE_SHAPE,
+                      is_training=True,
+                      num_classes=2,
+                      learning_rate=1e-4)
+
+    print("RefineNet-ResNet-50 has {} parameters.".format(model.num_params))
+
+    
+    # generate a random image
+    random_image = np.random.rand(1, INPUT_IMAGE_SHAPE[0], INPUT_IMAGE_SHAPE[1], 3)
+    print("image shape: ", random_image.shape)
+
+    # generate a random label (0 or 1) for each pixel
+    random_annotation = np.random.randint(0, 2, (1, INPUT_IMAGE_SHAPE[0], INPUT_IMAGE_SHAPE[1], 1))
+    print("annotation shape: ", random_annotation.shape)
+
+    # train for one iteration
+    loss_val, _ = model.sess.run([model.loss, model.train_op], 
+                   feed_dict={model.placeholders["image"]: random_image, 
+                              model.placeholders["annotation"]: random_annotation})
+    
+    # check results
+    print("loss_val: ", loss_val)
+
+    print('test finished.')

--- a/refinenet/resnet/resnet_utils.py
+++ b/refinenet/resnet/resnet_utils.py
@@ -1,0 +1,249 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains building blocks for various versions of Residual Networks.
+
+Residual networks (ResNets) were proposed in:
+  Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
+  Deep Residual Learning for Image Recognition. arXiv:1512.03385, 2015
+
+More variants were introduced in:
+  Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
+  Identity Mappings in Deep Residual Networks. arXiv: 1603.05027, 2016
+
+We can obtain different ResNet variants by changing the network depth, width,
+and form of residual unit. This module implements the infrastructure for
+building them. Concrete ResNet units and full ResNet networks are implemented in
+the accompanying resnet_v1.py and resnet_v2.py modules.
+
+Compared to https://github.com/KaimingHe/deep-residual-networks, in the current
+implementation we subsample the output activations in the last residual unit of
+each block, instead of subsampling the input activations in the first residual
+unit of each block. The two implementations give identical results but our
+implementation is more memory efficient.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import tensorflow as tf
+
+slim = tf.contrib.slim
+
+
+class Block(collections.namedtuple('Block', ['scope', 'unit_fn', 'args'])):
+  """A named tuple describing a ResNet block.
+
+  Its parts are:
+    scope: The scope of the `Block`.
+    unit_fn: The ResNet unit function which takes as input a `Tensor` and
+      returns another `Tensor` with the output of the ResNet unit.
+    args: A list of length equal to the number of units in the `Block`. The list
+      contains one (depth, depth_bottleneck, stride) tuple for each unit in the
+      block to serve as argument to unit_fn.
+  """
+
+
+def subsample(inputs, factor, scope=None):
+  """Subsamples the input along the spatial dimensions.
+
+  Args:
+    inputs: A `Tensor` of size [batch, height_in, width_in, channels].
+    factor: The subsampling factor.
+    scope: Optional variable_scope.
+
+  Returns:
+    output: A `Tensor` of size [batch, height_out, width_out, channels] with the
+      input, either intact (if factor == 1) or subsampled (if factor > 1).
+  """
+  if factor == 1:
+    return inputs
+  else:
+    return slim.max_pool2d(inputs, [1, 1], stride=factor, scope=scope)
+
+
+def conv2d_same(inputs, num_outputs, kernel_size, stride, rate=1, scope=None):
+  """Strided 2-D convolution with 'SAME' padding.
+
+  When stride > 1, then we do explicit zero-padding, followed by conv2d with
+  'VALID' padding.
+
+  Note that
+
+     net = conv2d_same(inputs, num_outputs, 3, stride=stride)
+
+  is equivalent to
+
+     net = slim.conv2d(inputs, num_outputs, 3, stride=1, padding='SAME')
+     net = subsample(net, factor=stride)
+
+  whereas
+
+     net = slim.conv2d(inputs, num_outputs, 3, stride=stride, padding='SAME')
+
+  is different when the input's height or width is even, which is why we add the
+  current function. For more details, see ResnetUtilsTest.testConv2DSameEven().
+
+  Args:
+    inputs: A 4-D tensor of size [batch, height_in, width_in, channels].
+    num_outputs: An integer, the number of output filters.
+    kernel_size: An int with the kernel_size of the filters.
+    stride: An integer, the output stride.
+    rate: An integer, rate for atrous convolution.
+    scope: Scope.
+
+  Returns:
+    output: A 4-D tensor of size [batch, height_out, width_out, channels] with
+      the convolution output.
+  """
+  if stride == 1:
+    return slim.conv2d(inputs, num_outputs, kernel_size, stride=1, rate=rate,
+                       padding='SAME', scope=scope)
+  else:
+    kernel_size_effective = kernel_size + (kernel_size - 1) * (rate - 1)
+    pad_total = kernel_size_effective - 1
+    pad_beg = pad_total // 2
+    pad_end = pad_total - pad_beg
+    inputs = tf.pad(inputs,
+                    [[0, 0], [pad_beg, pad_end], [pad_beg, pad_end], [0, 0]])
+    return slim.conv2d(inputs, num_outputs, kernel_size, stride=stride,
+                       rate=rate, padding='VALID', scope=scope)
+
+
+@slim.add_arg_scope
+def stack_blocks_dense(net, blocks, output_stride=None,
+                       outputs_collections=None):
+  """Stacks ResNet `Blocks` and controls output feature density.
+
+  First, this function creates scopes for the ResNet in the form of
+  'block_name/unit_1', 'block_name/unit_2', etc.
+
+  Second, this function allows the user to explicitly control the ResNet
+  output_stride, which is the ratio of the input to output spatial resolution.
+  This is useful for dense prediction tasks such as semantic segmentation or
+  object detection.
+
+  Most ResNets consist of 4 ResNet blocks and subsample the activations by a
+  factor of 2 when transitioning between consecutive ResNet blocks. This results
+  to a nominal ResNet output_stride equal to 8. If we set the output_stride to
+  half the nominal network stride (e.g., output_stride=4), then we compute
+  responses twice.
+
+  Control of the output feature density is implemented by atrous convolution.
+
+  Args:
+    net: A `Tensor` of size [batch, height, width, channels].
+    blocks: A list of length equal to the number of ResNet `Blocks`. Each
+      element is a ResNet `Block` object describing the units in the `Block`.
+    output_stride: If `None`, then the output will be computed at the nominal
+      network stride. If output_stride is not `None`, it specifies the requested
+      ratio of input to output spatial resolution, which needs to be equal to
+      the product of unit strides from the start up to some level of the ResNet.
+      For example, if the ResNet employs units with strides 1, 2, 1, 3, 4, 1,
+      then valid values for the output_stride are 1, 2, 6, 24 or None (which
+      is equivalent to output_stride=24).
+    outputs_collections: Collection to add the ResNet block outputs.
+
+  Returns:
+    net: Output tensor with stride equal to the specified output_stride.
+
+  Raises:
+    ValueError: If the target output_stride is not valid.
+  """
+  # The current_stride variable keeps track of the effective stride of the
+  # activations. This allows us to invoke atrous convolution whenever applying
+  # the next residual unit would result in the activations having stride larger
+  # than the target output_stride.
+  current_stride = 1
+
+  # The atrous convolution rate parameter.
+  rate = 1
+
+  for block in blocks:
+    with tf.variable_scope(block.scope, 'block', [net]) as sc:
+      for i, unit in enumerate(block.args):
+        if output_stride is not None and current_stride > output_stride:
+          raise ValueError('The target output_stride cannot be reached.')
+
+        with tf.variable_scope('unit_%d' % (i + 1), values=[net]):
+          # If we have reached the target output_stride, then we need to employ
+          # atrous convolution with stride=1 and multiply the atrous rate by the
+          # current unit's stride for use in subsequent layers.
+          if output_stride is not None and current_stride == output_stride:
+            net = block.unit_fn(net, rate=rate, **dict(unit, stride=1))
+            rate *= unit.get('stride', 1)
+
+          else:
+            net = block.unit_fn(net, rate=1, **unit)
+            current_stride *= unit.get('stride', 1)
+      net = slim.utils.collect_named_outputs(outputs_collections, sc.name, net)
+
+  if output_stride is not None and current_stride != output_stride:
+    raise ValueError('The target output_stride cannot be reached.')
+
+  return net
+
+
+def resnet_arg_scope(weight_decay=0.0001,
+                     batch_norm_decay=0.997,
+                     batch_norm_epsilon=1e-5,
+                     batch_norm_scale=True,
+                     activation_fn=tf.nn.relu,
+                     use_batch_norm=True):
+  """Defines the default ResNet arg scope.
+
+  TODO(gpapan): The batch-normalization related default values above are
+    appropriate for use in conjunction with the reference ResNet models
+    released at https://github.com/KaimingHe/deep-residual-networks. When
+    training ResNets from scratch, they might need to be tuned.
+
+  Args:
+    weight_decay: The weight decay to use for regularizing the model.
+    batch_norm_decay: The moving average decay when estimating layer activation
+      statistics in batch normalization.
+    batch_norm_epsilon: Small constant to prevent division by zero when
+      normalizing activations by their variance in batch normalization.
+    batch_norm_scale: If True, uses an explicit `gamma` multiplier to scale the
+      activations in the batch normalization layer.
+    activation_fn: The activation function which is used in ResNet.
+    use_batch_norm: Whether or not to use batch normalization.
+
+  Returns:
+    An `arg_scope` to use for the resnet models.
+  """
+  batch_norm_params = {
+      'decay': batch_norm_decay,
+      'epsilon': batch_norm_epsilon,
+      'scale': batch_norm_scale,
+      'updates_collections': tf.GraphKeys.UPDATE_OPS,
+      'fused': None,  # Use fused batch norm if possible.
+  }
+
+  with slim.arg_scope(
+      [slim.conv2d],
+      weights_regularizer=slim.l2_regularizer(weight_decay),
+      weights_initializer=slim.variance_scaling_initializer(),
+      activation_fn=activation_fn,
+      normalizer_fn=slim.batch_norm if use_batch_norm else None,
+      normalizer_params=batch_norm_params):
+    with slim.arg_scope([slim.batch_norm], **batch_norm_params):
+      # The following implies padding='SAME' for pool1, which makes feature
+      # alignment easier for dense prediction tasks. This is also used in
+      # https://github.com/facebook/fb.resnet.torch. However the accompanying
+      # code of 'Deep Residual Learning for Image Recognition' uses
+      # padding='VALID' for pool1. You can switch to that choice by setting
+      # slim.arg_scope([slim.max_pool2d], padding='VALID').
+      with slim.arg_scope([slim.max_pool2d], padding='SAME') as arg_sc:
+        return arg_sc

--- a/refinenet/resnet/resnet_v2.py
+++ b/refinenet/resnet/resnet_v2.py
@@ -1,0 +1,337 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains definitions for the preactivation form of Residual Networks.
+
+Residual networks (ResNets) were originally proposed in:
+[1] Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
+    Deep Residual Learning for Image Recognition. arXiv:1512.03385
+
+The full preactivation 'v2' ResNet variant implemented in this module was
+introduced by:
+[2] Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
+    Identity Mappings in Deep Residual Networks. arXiv: 1603.05027
+
+The key difference of the full preactivation 'v2' variant compared to the
+'v1' variant in [1] is the use of batch normalization before every weight layer.
+
+Typical use:
+
+   from tensorflow.contrib.slim.nets import resnet_v2
+
+ResNet-101 for image classification into 1000 classes:
+
+   # inputs has shape [batch, 224, 224, 3]
+   with slim.arg_scope(resnet_v2.resnet_arg_scope()):
+      net, end_points = resnet_v2.resnet_v2_101(inputs, 1000, is_training=False)
+
+ResNet-101 for semantic segmentation into 21 classes:
+
+   # inputs has shape [batch, 513, 513, 3]
+   with slim.arg_scope(resnet_v2.resnet_arg_scope()):
+      net, end_points = resnet_v2.resnet_v2_101(inputs,
+                                                21,
+                                                is_training=False,
+                                                global_pool=False,
+                                                output_stride=16)
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from . import resnet_utils
+
+slim = tf.contrib.slim
+resnet_arg_scope = resnet_utils.resnet_arg_scope
+
+
+@slim.add_arg_scope
+def bottleneck(inputs, depth, depth_bottleneck, stride, rate=1,
+               outputs_collections=None, scope=None):
+  """Bottleneck residual unit variant with BN before convolutions.
+
+  This is the full preactivation residual unit variant proposed in [2]. See
+  Fig. 1(b) of [2] for its definition. Note that we use here the bottleneck
+  variant which has an extra bottleneck layer.
+
+  When putting together two consecutive ResNet blocks that use this unit, one
+  should use stride = 2 in the last unit of the first block.
+
+  Args:
+    inputs: A tensor of size [batch, height, width, channels].
+    depth: The depth of the ResNet unit output.
+    depth_bottleneck: The depth of the bottleneck layers.
+    stride: The ResNet unit's stride. Determines the amount of downsampling of
+      the units output compared to its input.
+    rate: An integer, rate for atrous convolution.
+    outputs_collections: Collection to add the ResNet unit output.
+    scope: Optional variable_scope.
+
+  Returns:
+    The ResNet unit's output.
+  """
+  with tf.variable_scope(scope, 'bottleneck_v2', [inputs]) as sc:
+    depth_in = slim.utils.last_dimension(inputs.get_shape(), min_rank=4)
+    preact = slim.batch_norm(inputs, activation_fn=tf.nn.relu, scope='preact')
+    if depth == depth_in:
+      shortcut = resnet_utils.subsample(inputs, stride, 'shortcut')
+    else:
+      shortcut = slim.conv2d(preact, depth, [1, 1], stride=stride,
+                             normalizer_fn=None, activation_fn=None,
+                             scope='shortcut')
+
+    residual = slim.conv2d(preact, depth_bottleneck, [1, 1], stride=1,
+                           scope='conv1')
+    residual = resnet_utils.conv2d_same(residual, depth_bottleneck, 3, stride,
+                                        rate=rate, scope='conv2')
+    residual = slim.conv2d(residual, depth, [1, 1], stride=1,
+                           normalizer_fn=None, activation_fn=None,
+                           scope='conv3')
+
+    output = shortcut + residual
+
+    return slim.utils.collect_named_outputs(outputs_collections,
+                                            sc.name,
+                                            output)
+
+
+def resnet_v2(inputs,
+              blocks,
+              num_classes=None,
+              is_training=True,
+              global_pool=True,
+              output_stride=None,
+              include_root_block=True,
+              spatial_squeeze=True,
+              reuse=None,
+              scope=None):
+  """Generator for v2 (preactivation) ResNet models.
+
+  This function generates a family of ResNet v2 models. See the resnet_v2_*()
+  methods for specific model instantiations, obtained by selecting different
+  block instantiations that produce ResNets of various depths.
+
+  Training for image classification on Imagenet is usually done with [224, 224]
+  inputs, resulting in [7, 7] feature maps at the output of the last ResNet
+  block for the ResNets defined in [1] that have nominal stride equal to 32.
+  However, for dense prediction tasks we advise that one uses inputs with
+  spatial dimensions that are multiples of 32 plus 1, e.g., [321, 321]. In
+  this case the feature maps at the ResNet output will have spatial shape
+  [(height - 1) / output_stride + 1, (width - 1) / output_stride + 1]
+  and corners exactly aligned with the input image corners, which greatly
+  facilitates alignment of the features to the image. Using as input [225, 225]
+  images results in [8, 8] feature maps at the output of the last ResNet block.
+
+  For dense prediction tasks, the ResNet needs to run in fully-convolutional
+  (FCN) mode and global_pool needs to be set to False. The ResNets in [1, 2] all
+  have nominal stride equal to 32 and a good choice in FCN mode is to use
+  output_stride=16 in order to increase the density of the computed features at
+  small computational and memory overhead, cf. http://arxiv.org/abs/1606.00915.
+
+  Args:
+    inputs: A tensor of size [batch, height_in, width_in, channels].
+    blocks: A list of length equal to the number of ResNet blocks. Each element
+      is a resnet_utils.Block object describing the units in the block.
+    num_classes: Number of predicted classes for classification tasks.
+      If 0 or None, we return the features before the logit layer.
+    is_training: whether batch_norm layers are in training mode.
+    global_pool: If True, we perform global average pooling before computing the
+      logits. Set to True for image classification, False for dense prediction.
+    output_stride: If None, then the output will be computed at the nominal
+      network stride. If output_stride is not None, it specifies the requested
+      ratio of input to output spatial resolution.
+    include_root_block: If True, include the initial convolution followed by
+      max-pooling, if False excludes it. If excluded, `inputs` should be the
+      results of an activation-less convolution.
+    spatial_squeeze: if True, logits is of shape [B, C], if false logits is
+        of shape [B, 1, 1, C], where B is batch_size and C is number of classes.
+        To use this parameter, the input images must be smaller than 300x300
+        pixels, in which case the output logit layer does not contain spatial
+        information and can be removed.
+    reuse: whether or not the network and its variables should be reused. To be
+      able to reuse 'scope' must be given.
+    scope: Optional variable_scope.
+
+
+  Returns:
+    net: A rank-4 tensor of size [batch, height_out, width_out, channels_out].
+      If global_pool is False, then height_out and width_out are reduced by a
+      factor of output_stride compared to the respective height_in and width_in,
+      else both height_out and width_out equal one. If num_classes is 0 or None,
+      then net is the output of the last ResNet block, potentially after global
+      average pooling. If num_classes is a non-zero integer, net contains the
+      pre-softmax activations.
+    end_points: A dictionary from components of the network to the corresponding
+      activation.
+
+  Raises:
+    ValueError: If the target output_stride is not valid.
+  """
+  with tf.variable_scope(scope, 'resnet_v2', [inputs], reuse=reuse) as sc:
+    end_points_collection = sc.original_name_scope + '_end_points'
+    with slim.arg_scope([slim.conv2d, bottleneck,
+                         resnet_utils.stack_blocks_dense],
+                        outputs_collections=end_points_collection):
+      with slim.arg_scope([slim.batch_norm], is_training=is_training):
+        net = inputs
+        if include_root_block:
+          if output_stride is not None:
+            if output_stride % 4 != 0:
+              raise ValueError('The output_stride needs to be a multiple of 4.')
+            output_stride /= 4
+          # We do not include batch normalization or activation functions in
+          # conv1 because the first ResNet unit will perform these. Cf.
+          # Appendix of [2].
+          with slim.arg_scope([slim.conv2d],
+                              activation_fn=None, normalizer_fn=None):
+            net = resnet_utils.conv2d_same(net, 64, 7, stride=2, scope='conv1')
+          net = slim.max_pool2d(net, [3, 3], stride=2, scope='pool1')
+        net = resnet_utils.stack_blocks_dense(net, blocks, output_stride)
+        # This is needed because the pre-activation variant does not have batch
+        # normalization or activation functions in the residual unit output. See
+        # Appendix of [2].
+        net = slim.batch_norm(net, activation_fn=tf.nn.relu, scope='postnorm')
+        # Convert end_points_collection into a dictionary of end_points.
+        end_points = slim.utils.convert_collection_to_dict(
+            end_points_collection)
+
+        if global_pool:
+          # Global average pooling.
+          net = tf.reduce_mean(net, [1, 2], name='pool5', keep_dims=True)
+          end_points['global_pool'] = net
+        if num_classes is not None:
+          net = slim.conv2d(net, num_classes, [1, 1], activation_fn=None,
+                            normalizer_fn=None, scope='logits')
+          end_points[sc.name + '/logits'] = net
+          if spatial_squeeze:
+            net = tf.squeeze(net, [1, 2], name='SpatialSqueeze')
+            end_points[sc.name + '/spatial_squeeze'] = net
+          end_points['predictions'] = slim.softmax(net, scope='predictions')
+        return net, end_points
+resnet_v2.default_image_size = 224
+
+
+def resnet_v2_block(scope, base_depth, num_units, stride):
+  """Helper function for creating a resnet_v2 bottleneck block.
+
+  Args:
+    scope: The scope of the block.
+    base_depth: The depth of the bottleneck layer for each unit.
+    num_units: The number of units in the block.
+    stride: The stride of the block, implemented as a stride in the last unit.
+      All other units have stride=1.
+
+  Returns:
+    A resnet_v2 bottleneck block.
+  """
+  return resnet_utils.Block(scope, bottleneck, [{
+      'depth': base_depth * 4,
+      'depth_bottleneck': base_depth,
+      'stride': 1
+  }] * (num_units - 1) + [{
+      'depth': base_depth * 4,
+      'depth_bottleneck': base_depth,
+      'stride': stride
+  }])
+resnet_v2.default_image_size = 224
+
+
+def resnet_v2_50(inputs,
+                 num_classes=None,
+                 is_training=True,
+                 global_pool=True,
+                 output_stride=None,
+                 spatial_squeeze=True,
+                 reuse=None,
+                 scope='resnet_v2_50'):
+  """ResNet-50 model of [1]. See resnet_v2() for arg and return description."""
+  blocks = [
+      resnet_v2_block('block1', base_depth=64, num_units=3, stride=2),
+      resnet_v2_block('block2', base_depth=128, num_units=4, stride=2),
+      resnet_v2_block('block3', base_depth=256, num_units=6, stride=2),
+      resnet_v2_block('block4', base_depth=512, num_units=3, stride=1),
+  ]
+  return resnet_v2(inputs, blocks, num_classes, is_training=is_training,
+                   global_pool=global_pool, output_stride=output_stride,
+                   include_root_block=True, spatial_squeeze=spatial_squeeze,
+                   reuse=reuse, scope=scope)
+resnet_v2_50.default_image_size = resnet_v2.default_image_size
+
+
+def resnet_v2_101(inputs,
+                  num_classes=None,
+                  is_training=True,
+                  global_pool=True,
+                  output_stride=None,
+                  spatial_squeeze=True,
+                  reuse=None,
+                  scope='resnet_v2_101'):
+  """ResNet-101 model of [1]. See resnet_v2() for arg and return description."""
+  blocks = [
+      resnet_v2_block('block1', base_depth=64, num_units=3, stride=2),
+      resnet_v2_block('block2', base_depth=128, num_units=4, stride=2),
+      resnet_v2_block('block3', base_depth=256, num_units=23, stride=2),
+      resnet_v2_block('block4', base_depth=512, num_units=3, stride=1),
+  ]
+  return resnet_v2(inputs, blocks, num_classes, is_training=is_training,
+                   global_pool=global_pool, output_stride=output_stride,
+                   include_root_block=True, spatial_squeeze=spatial_squeeze,
+                   reuse=reuse, scope=scope)
+resnet_v2_101.default_image_size = resnet_v2.default_image_size
+
+
+def resnet_v2_152(inputs,
+                  num_classes=None,
+                  is_training=True,
+                  global_pool=True,
+                  output_stride=None,
+                  spatial_squeeze=True,
+                  reuse=None,
+                  scope='resnet_v2_152'):
+  """ResNet-152 model of [1]. See resnet_v2() for arg and return description."""
+  blocks = [
+      resnet_v2_block('block1', base_depth=64, num_units=3, stride=2),
+      resnet_v2_block('block2', base_depth=128, num_units=8, stride=2),
+      resnet_v2_block('block3', base_depth=256, num_units=36, stride=2),
+      resnet_v2_block('block4', base_depth=512, num_units=3, stride=1),
+  ]
+  return resnet_v2(inputs, blocks, num_classes, is_training=is_training,
+                   global_pool=global_pool, output_stride=output_stride,
+                   include_root_block=True, spatial_squeeze=spatial_squeeze,
+                   reuse=reuse, scope=scope)
+resnet_v2_152.default_image_size = resnet_v2.default_image_size
+
+
+def resnet_v2_200(inputs,
+                  num_classes=None,
+                  is_training=True,
+                  global_pool=True,
+                  output_stride=None,
+                  spatial_squeeze=True,
+                  reuse=None,
+                  scope='resnet_v2_200'):
+  """ResNet-200 model of [2]. See resnet_v2() for arg and return description."""
+  blocks = [
+      resnet_v2_block('block1', base_depth=64, num_units=3, stride=2),
+      resnet_v2_block('block2', base_depth=128, num_units=24, stride=2),
+      resnet_v2_block('block3', base_depth=256, num_units=36, stride=2),
+      resnet_v2_block('block4', base_depth=512, num_units=3, stride=1),
+  ]
+  return resnet_v2(inputs, blocks, num_classes, is_training=is_training,
+                   global_pool=global_pool, output_stride=output_stride,
+                   include_root_block=True, spatial_squeeze=spatial_squeeze,
+                   reuse=reuse, scope=scope)
+resnet_v2_200.default_image_size = resnet_v2.default_image_size

--- a/refinenet/utils/wrangle_tiny_imagenet.py
+++ b/refinenet/utils/wrangle_tiny_imagenet.py
@@ -1,0 +1,82 @@
+"""
+This script helps convert the Tiny ImageNet dataset (200 classes) to a structure that Keras supports
+"""
+import os
+import argparse
+import shutil
+
+from tqdm import tqdm
+
+
+def process_training_data(path_to_data):
+	"""Move all images such that they are directly under their cateogry folder
+	"""
+	old_train_path = os.path.join(path_to_data, 'train')
+	new_train_path = os.path.join(path_to_data, 'train_keras')
+
+	# create new training data path if it does not exist
+	if not os.path.isdir(new_train_path):
+		os.mkdir(new_train_path)
+
+	for wnid in tqdm(os.listdir(old_train_path)):
+		assert len(wnid) == 9
+		# create a folder for this wnid if there is not one
+		if not os.path.isdir(os.path.join(new_train_path, wnid)):
+			os.mkdir(os.path.join(new_train_path, wnid))
+		for img_file in os.listdir(os.path.join(old_train_path, wnid, 'images')):
+			src = os.path.join(old_train_path, wnid, 'images', img_file)
+			dst = os.path.join(new_train_path, wnid, img_file)
+			shutil.copyfile(src, dst)
+
+def process_validation_data(path_to_data):
+	"""Move validation images to wnid folders based on their label
+	"""
+	old_val_path = os.path.join(path_to_data, 'val')
+	new_val_path = os.path.join(path_to_data, 'val_keras')
+
+	# create new training data path if it does not exist
+	if not os.path.isdir(new_val_path):
+		os.mkdir(new_val_path)
+	
+	# read from validation annotation file
+	label_to_images = {}
+	with open(os.path.join(old_val_path, 'val_annotations.txt'), 'r') as f:
+		lines = f.readlines()
+		for line in lines:
+			img_file, label = line.split()[:2]
+			if label not in label_to_images:
+				label_to_images[label] = []
+			label_to_images[label].append(img_file)
+
+	# create a folder for each wnid and copy images
+	for wnid in tqdm(label_to_images.keys()):
+		assert len(wnid) == 9
+		if not os.path.isdir(os.path.join(new_val_path, wnid)):
+			os.mkdir(os.path.join(new_val_path, wnid))
+		for img_file in label_to_images[wnid]:
+			src = os.path.join(old_val_path, 'images', img_file)
+			dst = os.path.join(new_val_path, wnid, img_file)
+			shutil.copyfile(src, dst)
+
+def main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument("path_to_data", default=None, help="Specify the path to imagenet data")
+	args = parser.parse_args()
+
+	try:
+		# process training data
+		print("start processing training data...")
+		process_training_data(args.path_to_data)
+
+		# process validation data
+		print("start processing validation data...")
+		process_validation_data(args.path_to_data)
+	except:
+		print("Exception caught. Removing copied images...")
+		if os.path.isdir(os.path.join(path_to_data, 'train_keras')):
+			shutil.rmtree(os.path.join(path_to_data, 'train_keras'))
+		if os.path.isdir(os.path.join(path_to_data, 'val_keras')):
+			shutil.rmtree(os.path.join(path_to_data, 'val_keras'))
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
This commit implements RefineNet in [1] Guosheng Lin, Anton Milan, Chunhua Shen, Ian Reid RefineNet: Multi-Path Refinement Networks for High-Resolution Semantic Segmentatiion. arXiv:1611.06612.

Main function in `refinenet.py` is used to check the model can build and run.

Since RefineNet relies on ResNet, `resnet_v2.py` and `resnet_utils.py` from `tensorflow.models.research.slim` are also added to this repo.